### PR TITLE
[feat] client side auth

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,7 @@
     "angular-ui-router": "~0.2.15",
     "font-awesome": "fontawesome#~4.5.0",
     "bootstrap": "~3.3.6",
-    "bootstrap-social": "~4.12.0"
+    "bootstrap-social": "~4.12.0",
+    "angular-cookies": "~1.4.8"
   }
 }

--- a/client/app/app.js
+++ b/client/app/app.js
@@ -10,5 +10,9 @@ angular.module('app', [
     .state('home', {
       templateUrl: 'app/components/home/home.html',
       url: '/'
-    });
+    })
+    .state('test', {
+      templateUrl: 'app/components/test/test.html',
+      url: '/test'
+    })
   }]);

--- a/client/app/app.js
+++ b/client/app/app.js
@@ -15,7 +15,7 @@ angular.module('app', [
     .state('test', {
       templateUrl: 'app/components/test/test.html',
       url: '/test'
-    })
+    });
   }])
   .run(['$rootScope','$state','$cookies','$window',function($rootScope, $state, $cookies, $window) {
     $rootScope.$on('$stateChangeStart', function(event, toState, toParams, fromState, fromParams) { 
@@ -23,18 +23,18 @@ angular.module('app', [
       //this value is undefined if a user has never logged in
       //it's also undefined if a user logged out
       var cookie = $cookies.get('connect.sid');
-      console.log("cookie", cookie);
+      console.log('cookie', cookie);
 
-      if(!cookie && toState.name === "home") {
-        console.log("hey I'm logged out");
+      if(!cookie && toState.name === 'home') {
+        console.log('hey I"m logged out');
         return;
-      } else if (!cookie && toState.name !== "home") {
-        console.log("I'm still logged out in another page");
+      } else if (!cookie && toState.name !== 'home') {
+        console.log('I"m still logged out in another page');
         event.preventDefault(); 
         $state.go('home');
         return;
       } else {
-        console.log("hey I'm logged in");
+        console.log('hey I"m logged in');
       }    
-    })
+    });
   }]);

--- a/client/app/app.js
+++ b/client/app/app.js
@@ -1,6 +1,7 @@
 angular.module('app', [
   'ui.router',
-  'app.home'
+  'app.home',
+  'ngCookies'
   ])
   .config(['$stateProvider','$urlRouterProvider', function($stateProvider, $urlRouterProvider) {
 

--- a/client/app/app.js
+++ b/client/app/app.js
@@ -16,4 +16,25 @@ angular.module('app', [
       templateUrl: 'app/components/test/test.html',
       url: '/test'
     })
+  }])
+  .run(['$rootScope','$state','$cookies','$window',function($rootScope, $state, $cookies, $window) {
+    $rootScope.$on('$stateChangeStart', function(event, toState, toParams, fromState, fromParams) { 
+
+      //this value is undefined if a user has never logged in
+      //it's also undefined if a user logged out
+      var cookie = $cookies.get('connect.sid');
+      console.log("cookie", cookie);
+
+      if(!cookie && toState.name === "home") {
+        console.log("hey I'm logged out");
+        return;
+      } else if (!cookie && toState.name !== "home") {
+        console.log("I'm still logged out in another page");
+        event.preventDefault(); 
+        $state.go('home');
+        return;
+      } else {
+        console.log("hey I'm logged in");
+      }    
+    })
   }]);

--- a/client/app/components/home/home.html
+++ b/client/app/components/home/home.html
@@ -7,4 +7,12 @@
 				</button>
 			</form>
 		</div>
+
+    <div>
+      <form method='get' action='/logout' class="form-inline">
+        <button type="submit">
+        Logout button
+      </form>
+    </div>
+
 </div>

--- a/client/app/components/home/home.html
+++ b/client/app/components/home/home.html
@@ -7,12 +7,10 @@
 				</button>
 			</form>
 		</div>
-
     <div>
       <form method='get' action='/logout' class="form-inline">
         <button type="submit">
-        Logout button
+        Logout Button
       </form>
     </div>
-
 </div>

--- a/client/app/components/test/test.html
+++ b/client/app/components/test/test.html
@@ -1,0 +1,1 @@
+<div> Hey I can access this test angular route </div>

--- a/client/app/components/test/testController.js
+++ b/client/app/components/test/testController.js
@@ -1,0 +1,3 @@
+angular.module('app.test', [])
+  .controller('TestController', [function () {
+  }]);

--- a/client/index.html
+++ b/client/index.html
@@ -16,15 +16,14 @@
         <!-- bower components -->
         <script src="bower_components/angular/angular.min.js"></script>
         <script src="bower_components/angular-ui-router/release/angular-ui-router.min.js"></script>
-        
-        
+        <script src="bower_components/angular-cookies/angular-cookies.min.js"></script>
         <!-- main config/routing -->
         <script src="app/app.js"></script>
 
         <!-- controllers -->
         <script src="app/components/home/homeController.js"></script>
         <script src="app/components/test/testController.js"></script>
-        
+
         <!-- shared services -->
         <!-- component services -->
         <!-- custom directives -->

--- a/client/index.html
+++ b/client/index.html
@@ -23,6 +23,7 @@
 
         <!-- controllers -->
         <script src="app/components/home/homeController.js"></script>
+        <script src="app/components/test/testController.js"></script>
         
         <!-- shared services -->
         <!-- component services -->

--- a/server/config/middleware.js
+++ b/server/config/middleware.js
@@ -25,10 +25,16 @@ module.exports = function(app, express) {
     res.send('you don\'t have access to that resource. redirecting to sign in.');
   });
 
-  // app.get('/', function(req, res) {
-  //   res.status('200');
-  //   res.send("Hello World");
-  // });
+  app.get('/resource', githubSessions.restrict, function(req, res) {
+    res.status('200');
+    res.send("you have access to this resource");
+  });
+
+  app.get('/logout', function(req, res) {
+    req.session.destroy();
+    res.send("destroyed session");
+  });
+
   require(__dirname + './../auth/authRoutes.js')(authRouter);
 };
 

--- a/server/config/middleware.js
+++ b/server/config/middleware.js
@@ -31,8 +31,10 @@ module.exports = function(app, express) {
   });
 
   app.get('/logout', function(req, res) {
-    req.session.destroy();
-    res.send("destroyed session");
+    req.session.destroy(function() {
+      res.clearCookie('connect.sid', { path: '/' });
+      res.redirect('/');
+    });
   });
 
   require(__dirname + './../auth/authRoutes.js')(authRouter);

--- a/server/config/middleware.js
+++ b/server/config/middleware.js
@@ -27,7 +27,7 @@ module.exports = function(app, express) {
 
   app.get('/resource', githubSessions.restrict, function(req, res) {
     res.status('200');
-    res.send("you have access to this resource");
+    res.send('you have access to this resource');
   });
 
   app.get('/logout', function(req, res) {


### PR DESCRIPTION
## Summary of Changes

When Passport authenticates it has a cookie. The client checks to see if the cookie exists. If it does, it lets you access any route. If it doesn't, it redirects to home route.
- add `/logout` route to clear cookies
- added test component to test client side auth since home is currently the only route
