### PR TITLE
[feat] add cookie with user profile

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -17,11 +17,15 @@ angular.module('app', [
       url: '/test'
     });
   }])
-  .run(['$rootScope','$state','$cookies','$window',function($rootScope, $state, $cookies, $window) {
+  .run(['$rootScope','$state','$cookies','$window', function($rootScope, $state, $cookies, $window) {
     $rootScope.$on('$stateChangeStart', function(event, toState, toParams, fromState, fromParams) { 
 
-      //this value is undefined if a user has never logged in
-      //it's also undefined if a user logged out
+      var s = $cookies.get('user-profile');
+      if (s) {
+        var profileObj = s.substring(s.indexOf("{"), s.lastIndexOf("}") + 1);
+        console.log("profile", profileObj);
+      }
+
       var cookie = $cookies.get('connect.sid');
       console.log('cookie', cookie);
 
@@ -37,4 +41,6 @@ angular.module('app', [
         console.log('hey I"m logged in');
       }    
     });
+
   }]);
+

--- a/client/app/app.js
+++ b/client/app/app.js
@@ -22,8 +22,8 @@ angular.module('app', [
 
       var s = $cookies.get('user-profile');
       if (s) {
-        var profileObj = s.substring(s.indexOf("{"), s.lastIndexOf("}") + 1);
-        console.log("profile", profileObj);
+        var profileObj = s.substring(s.indexOf('{'), s.lastIndexOf('}') + 1);
+        console.log('profile', profileObj);
       }
 
       var cookie = $cookies.get('connect.sid');

--- a/server/auth/authHandler.js
+++ b/server/auth/authHandler.js
@@ -12,7 +12,7 @@ module.exports = {
       displayName: req.user.displayName,
       avatar: req.user._json.avatar_url,
       location: req.user._json.location
-    }
+    };
 
     res.cookie('user-profile', profile, { maxAge: 2592000000 });  // Expires in one month
 

--- a/server/auth/authHandler.js
+++ b/server/auth/authHandler.js
@@ -5,6 +5,17 @@ module.exports = {
 	redirect:  passport.authenticate('github', {failureRedirect: '/failure'}),
 
 	success: function(req, res) {
+
+    var profile = {
+      id: req.user.id,
+      username: req.user.username,
+      displayName: req.user.displayName,
+      avatar: req.user._json.avatar_url,
+      location: req.user._json.location
+    }
+
+    res.cookie('user-profile', profile, { maxAge: 2592000000 });  // Expires in one month
+
     // Successful authentication, redirect home.
     res.redirect('/');
   }

--- a/server/config/middleware.js
+++ b/server/config/middleware.js
@@ -33,6 +33,7 @@ module.exports = function(app, express) {
   app.get('/logout', function(req, res) {
     req.session.destroy(function() {
       res.clearCookie('connect.sid', { path: '/' });
+      res.clearCookie('user-profile');
       res.redirect('/');
     });
   });


### PR DESCRIPTION
## Summary of Changes

When a user logs in, Angular now has access to the following profile information:

```
{"id":"3048412",
"username":"polinadotio",
"displayName":"Polina Soshnin",
"avatar":"https://avatars.githubusercontent.com/u/3048412?v=3",
"location":"San Francisco"}
```
